### PR TITLE
add taskfile and CI/CD actions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Check
+on: [push]
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: License
+        uses: apache/skywalking-eyes@main
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.18.0'
+      - name: Test
+        run: go test -v -cover

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: fl-release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: License
+        uses: apache/skywalking-eyes@main
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.18.0'
+      - name: Test
+        run: go test -v -cover
+  releases-matrix:
+    name: Release fl binary
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, darwin/amd64, darwin/arm64
+        goos: [linux, windows, darwin]
+        goarch: ["386", amd64, arm64]
+        exclude:
+          - goarch: "386"
+            goos: darwin
+          - goarch: arm64
+            goos: windows
+    steps:
+    - uses: actions/checkout@v3
+    - uses: wangyoucao577/go-release-action@v1.26
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        goos: ${{ matrix.goos }}
+        goarch: ${{ matrix.goarch }}
+        binary_name: "f"
+        extra_files: LICENSE README.md

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,10 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+fl
+
+.task
+vendor/
+bin/
+config/

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: Apache Software Foundation
+
+  paths-ignore:
+    - 'go.sum'
+    - '**/.task/**'
+    - '**/LICENSE'
+    - '**/build/**'
+    - '**/target/**'
+    - '**/task/**'
+    - '**/vendor/**'
+    - 'workspace.code-workspace'
+    - CODEOWNERS

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+-->
 # funless-cli

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+version: '3'
+vars:
+  BASETAG: 0.0.1
+  MILESTONE: todo #TODO
+  FL:
+    sh: echo ${GOBIN:-.}/fl
+  TAG:
+    sh: git describe --tags --abbrev=0 2>/dev/null || echo {{.MILESTONE}}-latest
+
+tasks:
+
+  default: task --list-all
+
+  cli-tag: git tag -d $(git tag) ; git tag -f v{{.BASETAG}}.$(date +%y%m%d%H)
+
+  build:
+    cmds:
+      - go build -ldflags "-X main.FLVersion={{.TAG}}" -o ./fl
+    sources:
+      - "*.go"
+      - "embed/*"
+    generates:
+      - "{{.FL}}"
+
+  install:
+    deps: [build]
+    cmds:
+      - cp ./fl {{.FL}}
+
+  vendor:
+    cmds:
+      - go mod vendor
+    status:
+      - test -d vendor
+
+  test:
+    cmds:
+      - go test -v -cover
+
+  debug:
+    deps:
+      - vendor
+    cmds:
+      - go build -gcflags '-N -l' -mod=vendor -ldflags "-X main.FLVersion={{.TAG}}" -o {{.FL}}-debug
+    generates:
+      - "{{.FL}}-debug"
+
+  clean: rm -f {{.FL}} {{.FL}}-debug
+  setup: {silent:true} 


### PR DESCRIPTION
This PR closes #4.

It adds support for the go-task tool with a Taskfile.yml which defines tasks to build the project in normal and debug mode, test it and clean up
and 2 github wokflows.
1. check.yml: One to build, check licenses and run tests
2. release.yml: when pushing a v*.*.* tag it checks licenses and run tests and then builds the cli tool for all platforms and uploads them as a release in github